### PR TITLE
Fix build failure caused by trying to build `cffi`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 # Container image that runs your code
 FROM python:alpine
 
+RUN apk update && apk add gcc libc-dev make git libffi-dev openssl-dev python3-dev libxml2-dev libxslt-dev 
+
 RUN pip install --no-cache-dir pygithub
 COPY entrypoint.py /entrypoint.py
 


### PR DESCRIPTION
All of our bundle release workflows were failing because the `actions-github-release` workflow was failing: (see [here](https://github.com/warpdotdev/warp-internal/runs/4759753358?check_suite_focus=true) as an example).

It seems that the `alpine` container didn't contain the necessary dependencies to build `cffi` (see [this](https://stackoverflow.com/questions/57520642/building-a-docker-image-for-a-flask-app-fails-in-pip) stackoverflow post).

Verified this fix works by trying to build the image.