### PR TITLE
Use GITHUB_OUTPUT file instead of set-output.

### DIFF
--- a/entrypoint.py
+++ b/entrypoint.py
@@ -6,29 +6,31 @@ wanted_release = os.environ['channel']
 repository = os.environ['repository']
 token = os.getenv('token', None)
 
+output = open(os.environ['GITHUB_OUTPUT'], 'a')
+
 G = Github(token)
 repo = G.get_repo(repository)
 releases = repo.get_releases()
 for release in releases:
     if wanted_release == 'stable':
         if release.body == "Warp Stable release":
-            print('::set-output name=release::{}'.format(release.tag_name))
+            output.write('release={}\n'.format(release.tag_name))
             break
     elif wanted_release == 'beta':
         if release.body == "Warp Beta release":
-            print('::set-output name=release::{}'.format(release.tag_name))
+            output.write('release={}\n'.format(release.tag_name))
             break
     elif wanted_release == 'canary':
         if release.body == "Nightly Warp Canary release":
-            print('::set-output name=release::{}'.format(release.tag_name))
+            output.write('release={}\n'.format(release.tag_name))
             break
     elif wanted_release == 'preview':
         if release.body == "Nightly Warp Preview release":
-            print('::set-output name=release::{}'.format(release.tag_name))
+            output.write('release={}\n'.format(release.tag_name))
             break
     elif wanted_release == 'dev':
         if release.body == "Nightly Warp Dev release":
-            print('::set-output name=release::{}'.format(release.tag_name))
+            output.write('release={}\n'.format(release.tag_name))
             break
     else:
         print('Can\'t get release')


### PR DESCRIPTION
Using `set-output` is deprecated; we should write output lines to the file pointed to by `GITHUB_OUTPUT` instead.

I tested this manually by commenting out the bits that used the GitHub library and faking some input data, and making sure the action appended lines as expected to the output file.